### PR TITLE
Fix script name in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-Start backend command: node server.js
+Start backend command: `node index.js`
 
-Start frontend command: npm start
+Start frontend command: `npm start`


### PR DESCRIPTION
To start the backend we need to run `node index.js` instead of `node server.js`